### PR TITLE
Return an ExecerContext if conn is an execer

### DIFF
--- a/sqlhooks.go
+++ b/sqlhooks.go
@@ -120,6 +120,14 @@ func (conn *ExecerContext) ExecContext(ctx context.Context, query string, args [
 	return results, err
 }
 
+func (conn *ExecerContext) Exec(query string, args []driver.Value) (driver.Result, error) {
+	// We have to implement Exec since it is required in the current version of
+	// Go for it to run ExecContext. From Go 10 it will be optional. However,
+	// this code should never run since database/sql always prefers to run
+	// ExecContext.
+	return nil, errors.New("Exec was called when ExecContext was implemented")
+}
+
 // Stmt implements a database/sql/driver.Stmt
 type Stmt struct {
 	Stmt  driver.Stmt

--- a/sqlhooks_test.go
+++ b/sqlhooks_test.go
@@ -154,3 +154,14 @@ func (s *suite) testHooksErrors(t *testing.T, query string) {
 func (s *suite) TestHooksErrors(t *testing.T, query string) {
 	t.Run("TestHooksErrors", func(t *testing.T) { s.testHooksErrors(t, query) })
 }
+
+func TestNamedValueToValue(t *testing.T) {
+	named := []driver.NamedValue{
+		{Ordinal: 1, Value: "foo"},
+		{Ordinal: 2, Value: 42},
+	}
+	want := []driver.Value{"foo", 42}
+	dargs, err := namedValueToValue(named)
+	require.NoError(t, err)
+	assert.Equal(t, want, dargs)
+}


### PR DESCRIPTION
A `driver.Conn` can optionally implement `driver.ExecerContext` or
`driver.Execer`. When they do, instead of creating a prepared statement and then
executing that `database/sql` will directly call `ExecContext` or `Exec`
respectively. We need to implement this since some drivers do not support all
statements being prepared first. For example in postgresql you can run multiple
statements in a `conn.Exec`, but it will fail if you try to prepare multiple
statements in one call.