### PR TITLE
handler sql error

### DIFF
--- a/hooks/loghooks/loghooks.go
+++ b/hooks/loghooks/loghooks.go
@@ -28,3 +28,9 @@ func (h *Hook) After(ctx context.Context, query string, args ...interface{}) (co
 	h.log.Printf("Query: `%s`, Args: `%q`. took: %s", query, args, time.Since(ctx.Value("started").(time.Time)))
 	return ctx, nil
 }
+
+func (h *Hook) OnError(ctx context.Context, err error, query string, args ...interface{}) error {
+	h.log.Printf("Error: %v, Query: `%s`, Args: `%q`, Took: %s",
+		err, query, args, time.Since(ctx.Value("started").(time.Time)))
+	return err
+}

--- a/hooks/othooks/othooks.go
+++ b/hooks/othooks/othooks.go
@@ -1,8 +1,11 @@
 package othooks
 
-import "context"
-import "github.com/opentracing/opentracing-go"
-import "github.com/opentracing/opentracing-go/log"
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+)
 
 type Hook struct {
 	tracer opentracing.Tracer
@@ -34,4 +37,17 @@ func (h *Hook) After(ctx context.Context, query string, args ...interface{}) (co
 	}
 
 	return ctx, nil
+}
+
+func (h *Hook) OnError(ctx context.Context, err error, query string, args ...interface{}) error {
+	span := opentracing.SpanFromContext(ctx)
+	if span != nil {
+		defer span.Finish()
+		span.SetTag("error", true)
+		span.LogFields(
+			log.Error(err),
+		)
+	}
+
+	return err
 }

--- a/sqlhooks_mysql_test.go
+++ b/sqlhooks_mysql_test.go
@@ -33,6 +33,7 @@ func TestMySQL(t *testing.T) {
 	s.TestHooksExecution(t, "SELECT * FROM users WHERE id = ?", 1)
 	s.TestHooksArguments(t, "SELECT * FROM users WHERE id = ? AND name = ?", int64(1), "Gus")
 	s.TestHooksErrors(t, "SELECT 1+1")
+	s.TestErrHookHook(t, "SELECT * FROM users WHERE id = $2", "INVALID_ARGS")
 
 	t.Run("DBWorks", func(t *testing.T) {
 		s.hooks.noop()

--- a/sqlhooks_postgres_test.go
+++ b/sqlhooks_postgres_test.go
@@ -33,6 +33,7 @@ func TestPostgres(t *testing.T) {
 	s.TestHooksExecution(t, "SELECT * FROM users WHERE id = $1", 1)
 	s.TestHooksArguments(t, "SELECT * FROM users WHERE id = $1 AND name = $2", int64(1), "Gus")
 	s.TestHooksErrors(t, "SELECT 1+1")
+	s.TestErrHookHook(t, "SELECT * FROM users WHERE id = $2", "INVALID_ARGS")
 
 	t.Run("DBWorks", func(t *testing.T) {
 		s.hooks.noop()

--- a/sqlhooks_sqlite3_test.go
+++ b/sqlhooks_sqlite3_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	sqlite3 "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,6 +31,7 @@ func TestSQLite3(t *testing.T) {
 	s.TestHooksExecution(t, "SELECT * FROM users WHERE id = ?", 1)
 	s.TestHooksArguments(t, "SELECT * FROM users WHERE id = ? AND name = ?", int64(1), "Gus")
 	s.TestHooksErrors(t, "SELECT 1+1")
+	s.TestErrHookHook(t, "SELECT * FROM users WHERE id = $2", "INVALID_ARGS")
 
 	t.Run("DBWorks", func(t *testing.T) {
 		s.hooks.noop()


### PR DESCRIPTION
Now if any SQL error happens, After hook will not be called.
It's cause OpenTracing span can't be finished normally. And the span will disappear on OpenTracing dashboard(I'm using Jaeger). 
It makes lot's of inconvenient because the only thing I really care about is the error message.