### PR TITLE
Add QueryerContext interface

### DIFF
--- a/sqlhooks.go
+++ b/sqlhooks.go
@@ -235,16 +235,6 @@ type SessionResetter struct {
 	*Conn
 }
 
-func isSessionResetter(conn driver.Conn) bool {
-	_, ok := conn.(driver.SessionResetter)
-	return ok
-}
-
-func (s *SessionResetter) ResetSession(ctx context.Context) error {
-	c := s.Conn.Conn.(driver.SessionResetter)
-	return c.ResetSession(ctx)
-}
-
 // Stmt implements a database/sql/driver.Stmt
 type Stmt struct {
 	Stmt  driver.Stmt

--- a/sqlhooks.go
+++ b/sqlhooks.go
@@ -236,21 +236,13 @@ type SessionResetter struct {
 }
 
 func isSessionResetter(conn driver.Conn) bool {
-	switch conn.(type) {
-	case driver.SessionResetter:
-		return true
-	default:
-		return false
-	}
+	_, ok := conn.(driver.SessionResetter)
+	return ok
 }
 
 func (s *SessionResetter) ResetSession(ctx context.Context) error {
-	switch c := s.Conn.Conn.(type) {
-	case driver.SessionResetter:
-		return c.ResetSession(ctx)
-	}
-
-	return nil
+	c := s.Conn.Conn.(driver.SessionResetter)
+	return c.ResetSession(ctx)
 }
 
 // Stmt implements a database/sql/driver.Stmt

--- a/sqlhooks_1_10.go
+++ b/sqlhooks_1_10.go
@@ -1,0 +1,18 @@
+// +build go1.10
+
+package sqlhooks
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+func isSessionResetter(conn driver.Conn) bool {
+	_, ok := conn.(driver.SessionResetter)
+	return ok
+}
+
+func (s *SessionResetter) ResetSession(ctx context.Context) error {
+	c := s.Conn.Conn.(driver.SessionResetter)
+	return c.ResetSession(ctx)
+}

--- a/sqlhooks_1_10_interface_test.go
+++ b/sqlhooks_1_10_interface_test.go
@@ -1,0 +1,17 @@
+// +build go1.10
+
+package sqlhooks
+
+import "database/sql/driver"
+
+func init() {
+	interfaceTestCases = append(interfaceTestCases,
+		struct {
+			name               string
+			expectedInterfaces []interface{}
+		}{
+			"ExecerQueryerContextSessionResetter", []interface{}{
+				(*driver.ExecerContext)(nil),
+				(*driver.QueryerContext)(nil),
+				(*driver.SessionResetter)(nil)}})
+}

--- a/sqlhooks_interface_test.go
+++ b/sqlhooks_interface_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var interfaceTestCases = []struct {
+	name               string
+	expectedInterfaces []interface{}
+}{
+	{"Basic", []interface{}{(*driver.Conn)(nil)}},
+	{"Execer", []interface{}{(*driver.Execer)(nil)}},
+	{"ExecerContext", []interface{}{(*driver.ExecerContext)(nil)}},
+	{"Queryer", []interface{}{(*driver.QueryerContext)(nil)}},
+	{"QueryerContext", []interface{}{(*driver.QueryerContext)(nil)}},
+	{"ExecerQueryerContext", []interface{}{
+		(*driver.ExecerContext)(nil),
+		(*driver.QueryerContext)(nil)}},
+}
+
 type fakeDriver struct{}
 
 func (d *fakeDriver) Open(dsn string) (driver.Conn, error) {
@@ -100,25 +114,7 @@ func (*FakeConnSessionResetter) ResetSession(ctx context.Context) error {
 func TestInterfaces(t *testing.T) {
 	drv := Wrap(&fakeDriver{}, &testHooks{})
 
-	cases := []struct {
-		name               string
-		expectedInterfaces []interface{}
-	}{
-		{"Basic", []interface{}{(*driver.Conn)(nil)}},
-		{"Execer", []interface{}{(*driver.Execer)(nil)}},
-		{"ExecerContext", []interface{}{(*driver.ExecerContext)(nil)}},
-		{"Queryer", []interface{}{(*driver.QueryerContext)(nil)}},
-		{"QueryerContext", []interface{}{(*driver.QueryerContext)(nil)}},
-		{"ExecerQueryerContext", []interface{}{
-			(*driver.ExecerContext)(nil),
-			(*driver.QueryerContext)(nil)}},
-		{"ExecerQueryerContextSessionResetter", []interface{}{
-			(*driver.ExecerContext)(nil),
-			(*driver.QueryerContext)(nil),
-			(*driver.SessionResetter)(nil)}},
-	}
-
-	for _, c := range cases {
+	for _, c := range interfaceTestCases {
 		conn, err := drv.Open(c.name)
 		require.NoErrorf(t, err, "Driver name %s", c.name)
 

--- a/sqlhooks_interface_test.go
+++ b/sqlhooks_interface_test.go
@@ -1,0 +1,129 @@
+package sqlhooks
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDriver struct{}
+
+func (d *fakeDriver) Open(dsn string) (driver.Conn, error) {
+	switch dsn {
+	case "Basic":
+		return &struct{ *FakeConnBasic }{}, nil
+	case "Execer":
+		return &struct {
+			*FakeConnBasic
+			*FakeConnExecer
+		}{}, nil
+	case "ExecerContext":
+		return &struct {
+			*FakeConnBasic
+			*FakeConnExecerContext
+		}{}, nil
+	case "Queryer":
+		return &struct {
+			*FakeConnBasic
+			*FakeConnQueryer
+		}{}, nil
+	case "QueryerContext":
+		return &struct {
+			*FakeConnBasic
+			*FakeConnQueryerContext
+		}{}, nil
+	case "ExecerQueryerContext":
+		return &struct {
+			*FakeConnBasic
+			*FakeConnExecerContext
+			*FakeConnQueryerContext
+		}{}, nil
+	case "ExecerQueryerContextSessionResetter":
+		return &struct {
+			*FakeConnBasic
+			*FakeConnExecer
+			*FakeConnQueryer
+			*FakeConnSessionResetter
+		}{}, nil
+	}
+
+	return nil, errors.New("Fake driver not implemented")
+}
+
+// Conn implements a database/sql.driver.Conn
+type FakeConnBasic struct{}
+
+func (*FakeConnBasic) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("Not implemented")
+}
+func (*FakeConnBasic) Close() error {
+	return errors.New("Not implemented")
+}
+func (*FakeConnBasic) Begin() (driver.Tx, error) {
+	return nil, errors.New("Not implemented")
+}
+
+type FakeConnExecer struct{}
+
+func (*FakeConnExecer) Exec(query string, args []driver.Value) (driver.Result, error) {
+	return nil, errors.New("Not implemented")
+}
+
+type FakeConnExecerContext struct{}
+
+func (*FakeConnExecerContext) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	return nil, errors.New("Not implemented")
+}
+
+type FakeConnQueryer struct{}
+
+func (*FakeConnQueryer) Query(query string, args []driver.Value) (driver.Rows, error) {
+	return nil, errors.New("Not implemented")
+}
+
+type FakeConnQueryerContext struct{}
+
+func (*FakeConnQueryerContext) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	return nil, errors.New("Not implemented")
+}
+
+type FakeConnSessionResetter struct{}
+
+func (*FakeConnSessionResetter) ResetSession(ctx context.Context) error {
+	return errors.New("Not implemented")
+}
+
+func TestInterfaces(t *testing.T) {
+	drv := Wrap(&fakeDriver{}, &testHooks{})
+
+	cases := []struct {
+		name               string
+		expectedInterfaces []interface{}
+	}{
+		{"Basic", []interface{}{(*driver.Conn)(nil)}},
+		{"Execer", []interface{}{(*driver.Execer)(nil)}},
+		{"ExecerContext", []interface{}{(*driver.ExecerContext)(nil)}},
+		{"Queryer", []interface{}{(*driver.QueryerContext)(nil)}},
+		{"QueryerContext", []interface{}{(*driver.QueryerContext)(nil)}},
+		{"ExecerQueryerContext", []interface{}{
+			(*driver.ExecerContext)(nil),
+			(*driver.QueryerContext)(nil)}},
+		{"ExecerQueryerContextSessionResetter", []interface{}{
+			(*driver.ExecerContext)(nil),
+			(*driver.QueryerContext)(nil),
+			(*driver.SessionResetter)(nil)}},
+	}
+
+	for _, c := range cases {
+		conn, err := drv.Open(c.name)
+		require.NoErrorf(t, err, "Driver name %s", c.name)
+
+		for _, i := range c.expectedInterfaces {
+			assert.Implements(t, i, conn)
+		}
+	}
+}

--- a/sqlhooks_pre_1_10.go
+++ b/sqlhooks_pre_1_10.go
@@ -1,0 +1,17 @@
+// +build !go1.10
+
+package sqlhooks
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+)
+
+func isSessionResetter(conn driver.Conn) bool {
+	return false
+}
+
+func (s *SessionResetter) ResetSession(ctx context.Context) error {
+	return errors.New("SessionResetter not implemented")
+}


### PR DESCRIPTION
If we don't support QueryerContext, the db.Query() call will always do
"prepare" statement

Solves issue #22 