### PR TITLE
Implement driver.ConnBeginTx

### DIFF
--- a/sqlhooks.go
+++ b/sqlhooks.go
@@ -164,7 +164,7 @@ func (conn *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx
 	if ciCtx, is := conn.Conn.(driver.ConnBeginTx); is {
 		return ciCtx.BeginTx(ctx, opts)
 	}
-	return nil, errors.New("sqlhooks: driver does not support non-default isolation level")
+	return nil, errors.New("driver does not implement driver.ConnBeginTx")
 }
 
 // QueryerContext implements a database/sql.driver.QueryerContext

--- a/sqlhooks.go
+++ b/sqlhooks.go
@@ -160,6 +160,13 @@ func (conn *ExecerContext) Exec(query string, args []driver.Value) (driver.Resul
 	return nil, errors.New("Exec was called when ExecContext was implemented")
 }
 
+func (conn *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if ciCtx, is := conn.Conn.(driver.ConnBeginTx); is {
+		return ciCtx.BeginTx(ctx, opts)
+	}
+	return nil, errors.New("sqlhooks: driver does not support non-default isolation level")
+}
+
 // QueryerContext implements a database/sql.driver.QueryerContext
 type QueryerContext struct {
 	*Conn

--- a/sqlhooks_postgres_test.go
+++ b/sqlhooks_postgres_test.go
@@ -1,6 +1,7 @@
 package sqlhooks
 
 import (
+	"context"
 	"database/sql"
 	"os"
 	"testing"
@@ -53,5 +54,14 @@ func TestPostgres(t *testing.T) {
 			s.db.QueryRow("SELECT COUNT(*) FROM users").Scan(&count),
 		)
 		assert.Equal(t, 5, count)
+
+		{ // Should execute the query successfully when a transaction with non default isolation level is used.
+			var count int
+			tx, err := s.db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
+			if assert.NoError(t, err) {
+				require.NoError(t, tx.QueryRow("SELECT COUNT(*) FROM users").Scan(&count))
+				assert.Equal(t, 5, count)
+			}
+		}
 	})
 }


### PR DESCRIPTION
This change implements `driver.ConnBeginTx` interface so that sqlhooks can be used when a non default isolation level is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gchaincl/sqlhooks/24)
<!-- Reviewable:end -->
