### PR TITLE
Fix v2 import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ The purpose of sqlhooks is to provide a way to instrument your sql statements, m
 
 # Install
 ```bash
-go get github.com/gchaincl/sqlhooks
+go get github.com/gchaincl/sqlhooks/v2
 ```
 Requires Go >= 1.8.x
 
 ## Breaking changes
-`V1` isn't backward compatible with previous versions, if you want to fetch old versions, you can get them from [gopkg.in](http://gopkg.in/)
+`V2` isn't backward compatible with previous versions, if you want to fetch old versions, you can use go modules or get them from [gopkg.in](http://gopkg.in/)
 ```bash
-go get gopkg.in/gchaincl/sqlhooks.v0
+go get github.com/gchaincl/sqlhooks
+go get gopkg.in/gchaincl/sqlhooks.v1
 ```
 
 # Usage [![GoDoc](https://godoc.org/github.com/gchaincl/dotsql?status.svg)](https://godoc.org/github.com/gchaincl/sqlhooks)
@@ -28,7 +29,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gchaincl/sqlhooks"
+	"github.com/gchaincl/sqlhooks/v2"
 	"github.com/mattn/go-sqlite3"
 )
 

--- a/doc.go
+++ b/doc.go
@@ -10,7 +10,7 @@
 // 	"fmt"
 // 	"time"
 //
-// 	"github.com/gchaincl/sqlhooks"
+// 	"github.com/gchaincl/sqlhooks/v2"
 // 	"github.com/mattn/go-sqlite3"
 // )
 //

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gchaincl/sqlhooks
+module github.com/gchaincl/sqlhooks/v2
 
 go 1.13
 

--- a/hooks/loghooks/example_test.go
+++ b/hooks/loghooks/example_test.go
@@ -3,7 +3,7 @@ package loghooks
 import (
 	"database/sql"
 
-	"github.com/gchaincl/sqlhooks"
+	"github.com/gchaincl/sqlhooks/v2"
 	sqlite3 "github.com/mattn/go-sqlite3"
 )
 

--- a/hooks/loghooks/examples/main.go
+++ b/hooks/loghooks/examples/main.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	"log"
 
-	"github.com/gchaincl/sqlhooks"
-	"github.com/gchaincl/sqlhooks/hooks/loghooks"
+	"github.com/gchaincl/sqlhooks/v2"
+	"github.com/gchaincl/sqlhooks/v2/hooks/loghooks"
 	"github.com/mattn/go-sqlite3"
 )
 

--- a/hooks/othooks/examples/main.go
+++ b/hooks/othooks/examples/main.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"log"
 
-	"github.com/gchaincl/sqlhooks"
-	"github.com/gchaincl/sqlhooks/hooks/othooks"
+	"github.com/gchaincl/sqlhooks/v2"
+	"github.com/gchaincl/sqlhooks/v2/hooks/othooks"
 	"github.com/mattn/go-sqlite3"
 	"github.com/opentracing/opentracing-go"
 )

--- a/hooks/othooks/othooks_test.go
+++ b/hooks/othooks/othooks_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/gchaincl/sqlhooks"
+	"github.com/gchaincl/sqlhooks/v2"
 	sqlite3 "github.com/mattn/go-sqlite3"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"


### PR DESCRIPTION
This PR adds the `v2` suffix to sqlhooks import path.

Once merged, I'll release a v2.0.1 patch so the v2 can be used by other modules